### PR TITLE
Support for mobile and routing fixes

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -30,21 +30,21 @@ export default function MainPage() {
 
         <Features
           orientation="right"
-          imageSrc="/public/knowledge_ai.png"
+          imageSrc="/knowledge_ai.png"
           title={t('features.feature1Title')}
           description={t('features.feature1Description')}
         />
         <div className="h-1 bg-gray-200"></div>
         <Features
           orientation="left"
-          imageSrc="/public/smarter_team.png"
+          imageSrc="/smarter_team.png"
           title={t('features.feature2Title')}
           description={t('features.feature2Description')}
         />
         <div className="h-1 bg-gray-200"></div>
         <Features
           orientation="right"
-          imageSrc="/public/security.png"
+          imageSrc="/security.png"
           title={t('features.feature3Title')}
           description={t('features.feature3Description')}
         />

--- a/src/components/CookiesConsent.jsx
+++ b/src/components/CookiesConsent.jsx
@@ -4,72 +4,67 @@ import { useTranslation } from "react-i18next";
 export default function CookiesConsent() {
   const [isOpen, setIsOpen] = useState(true);
   const { t } = useTranslation();
+
   if (!isOpen) return null;
 
   return (
-    <div
-      className="fixed bottom-0 inset-x-0 pb-2 sm:pb-5"
-    >
-      <div className="max-w-7xl mx-auto px-2 sm:px-6 lg:px-8">
-        <div className="p-2 rounded-lg bg-indigo-600 shadow-lg sm:p-3">
-          <div className="flex items-center justify-between flex-wrap">
-            <div className="w-0 flex-1 flex items-center">
-              <span className="flex p-2 rounded-lg bg-indigo-800">
-                <svg
-                  className="h-6 w-6 text-white"
-                  xmlns="http://www.w3.org/2000/svg"
-                  fill="none"
-                  viewBox="0 0 24 24"
-                  stroke="currentColor"
-                  aria-hidden="true"
-                >
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth="2"
-                    d="M9 12h6m2 0a2 2 0 110 4H7a2 2 0 110-4h10zm0 0V6a2 2 0 00-2-2H9a2 2 0 00-2 2v6z"
-                  />
-                </svg>
+    <div className="fixed bottom-0 inset-x-0 pb-2 px-2 sm:px-6 z-50">
+      <div className="max-w-4xl mx-auto rounded-lg bg-indigo-600 p-3 sm:p-4 shadow-lg text-white">
+        <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
+          {/* Icon and message */}
+          <div className="flex items-start sm:items-center gap-3 flex-1">
+            <div className="p-2 rounded-lg bg-indigo-800 shrink-0">
+              <svg
+                className="h-6 w-6"
+                xmlns="http://www.w3.org/2000/svg"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+                aria-hidden="true"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth="2"
+                  d="M9 12h6m2 0a2 2 0 110 4H7a2 2 0 110-4h10zm0 0V6a2 2 0 00-2-2H9a2 2 0 00-2 2v6z"
+                />
+              </svg>
+            </div>
+            <p className="text-sm sm:text-base leading-snug">
+              <span className="block sm:hidden">
+                {t("cookiesConsent.message")}
               </span>
-              <p className="ml-3 font-medium text-white truncate">
-                <span className="md:hidden">We use cookies for better service.</span>
-                <span className="hidden md:inline">
-                  {t("cookiesConsent.message")}
-                </span>
-              </p>
-            </div>
-            <div className="order-3 mt-2 flex-shrink-0 w-full sm:order-2 sm:mt-0 sm:w-auto">
-              <a
-                href="/privacy/"
-                className="flex items-center justify-center px-4 py-2 border border-transparent rounded-md shadow-sm text-sm font-medium text-indigo-600 bg-white hover:bg-indigo-50"
+              <span className="hidden sm:block">
+                {t("cookiesConsent.message")}
+              </span>
+            </p>
+          </div>
+
+          {/* Buttons */}
+          <div className="flex items-center justify-between gap-3 flex-shrink-0">
+            <a
+              href="#/privacy"
+              className="px-4 py-2 bg-white text-indigo-600 text-sm font-medium rounded-md hover:bg-indigo-50 whitespace-nowrap"
+            >
+              {t("buttons.learnMore")}
+            </a>
+            <button
+              type="button"
+              className="p-2 rounded-md hover:bg-indigo-500 focus:outline-none focus:ring-2 focus:ring-white"
+              aria-label="Dismiss"
+              onClick={() => setIsOpen(false)}
+            >
+              <svg
+                className="h-5 w-5"
+                xmlns="http://www.w3.org/2000/svg"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+                aria-hidden="true"
               >
-                {t("buttons.learnMore")}
-              </a>
-            </div>
-            <div className="order-2 flex-shrink-0 sm:order-3 sm:ml-2">
-              <button
-                type="button"
-                className="flex p-2 rounded-md hover:bg-indigo-500 focus:outline-none focus:ring-2 focus:ring-white"
-                aria-label="Dismiss"
-                onClick={() => setIsOpen(false)}
-              >
-                <svg
-                  className="h-6 w-6 text-white"
-                  xmlns="http://www.w3.org/2000/svg"
-                  fill="none"
-                  viewBox="0 0 24 24"
-                  stroke="currentColor"
-                  aria-hidden="true"
-                >
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth="2"
-                    d="M6 18L18 6M6 6l12 12"
-                  />
-                </svg>
-              </button>
-            </div>
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M6 18L18 6M6 6l12 12" />
+              </svg>
+            </button>
           </div>
         </div>
       </div>

--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -84,7 +84,7 @@ export default function Footer() {
           <ul className="space-y-2 text-neutral-400">
             <li>
               <a
-                href="/privacy/"
+                href="#/privacy"
                 className="hover:text-white"
               >
                 {t('footer.privacy')}
@@ -92,7 +92,7 @@ export default function Footer() {
             </li>
             <li>
               <a
-                href="/terms/"
+                href="#/terms"
                 className="hover:text-white"
               >
                 {t('footer.terms')}

--- a/src/components/Hero.jsx
+++ b/src/components/Hero.jsx
@@ -7,7 +7,7 @@ function useTypewriterEffect(text, speed) {
 
     useEffect(() => {
         let index = 0;
-          setDisplayedText(''); // ✅ Reset text when input changes
+        setDisplayedText(''); // ✅ Reset text when input changes
         const interval = setInterval(() => {
             if (index < text.length) {
                 const nextChar = text.charAt(index);
@@ -47,8 +47,8 @@ export default function Hero({ videoUrl }) {
                     </p>
                 </div>
                 <div className="mt-8 lg:mt-0 lg:col-span-5 flex justify-center w-full h-full max-h-[450px]">
-                  <div className="w-full aspect-video max-w-lg lg:max-w-full flex justify-center items-center min-w-[200px]">
-                        {i18n.language  === 'bg' ? (
+                    <div className="w-full aspect-video max-w-lg lg:max-w-full flex justify-center items-center min-w-[200px]">
+                        {i18n.language === 'bg' ? (
                             <iframe
                                 width="100%"
                                 height="100%"
@@ -56,8 +56,7 @@ export default function Hero({ videoUrl }) {
                                 allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
                                 allowFullScreen
                                 title="Video BG"
-                                frameborder="0"
-                                webkitallowfullscreen mozallowfullscreen allowfullscreen
+                                webkitallowfullscreen="true" mozallowfullscreen="true" 
                             ></iframe>
 
 
@@ -67,7 +66,7 @@ export default function Hero({ videoUrl }) {
                                 height="100%"
                                 src="https://www.loom.com/embed/30012d67d8534cf88c7e974bca82f199?sid=333acb5d-678d-4c4c-81c7-dbe1634e08b6"
                                 allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-                                allowFullScreen
+                                webkitallowfullscreen="true" mozallowfullscreen="true" 
                                 title="Video EN"
                             ></iframe>
                         )}

--- a/src/components/LanguageSwitcher.jsx
+++ b/src/components/LanguageSwitcher.jsx
@@ -1,5 +1,4 @@
 import { useTranslation } from "react-i18next";
-import React from "react";
 import Flag from "react-world-flags";
 
 const languages = [
@@ -12,7 +11,7 @@ export function LanguageSwitcher() {
   const currentLang = i18n.language;
 
   return (
-    <div className="flex space-x-3 items-center px-10">
+    <div className="flex space-x-3 items-center px-5 py-5 sm:py-0">
       {languages.map((lang) => (
         <button
           key={lang.code}
@@ -24,7 +23,7 @@ export function LanguageSwitcher() {
         >
           <Flag
             code={lang.countryCode.toUpperCase()}
-            style={{ width: "35px",  borderRadius: "0px", border: "1px solid black" }}
+            style={{ width: "30px",  borderRadius: "0px", border: "1px solid black" }}
             title={lang.alt}
           />
         </button>

--- a/src/components/MarkdownViewer.jsx
+++ b/src/components/MarkdownViewer.jsx
@@ -7,7 +7,7 @@ const MarkdownViewer = ({ fileName }) => {
   const [markdown, setMarkdown] = useState('');
 
   useEffect(() => {
-    const lang = i18n.language || 'en';
+    const lang = (i18n.language || 'en').split('-')[0];
     const url = `/locales/${lang}/${fileName}`;
 
     fetch(url)

--- a/src/components/Menu.jsx
+++ b/src/components/Menu.jsx
@@ -33,7 +33,7 @@ export default function Menu() {
 
 				{/* Heading */}
 				<div className="mr-auto text-md font-semibold text-neutral-900 flex gap-1 items-center">
-					<img src="/public/logo-2.png" alt="ContextOps Logo" className="h-16 max-w-xs mr-1" />
+					<img src="/logo-2.png" alt="ContextOps Logo" className="h-16 max-w-xs mr-1" />
 					<span className="  whitespace-nowrap"> {t("menu.title")}</span>
 				</div>
 

--- a/src/components/Menu.jsx
+++ b/src/components/Menu.jsx
@@ -68,9 +68,9 @@ export default function Menu() {
 						{t("menu.contact")}
 					</a>
 
+					<LanguageSwitcher />
 
 				</nav>
-				<LanguageSwitcher />
 			</div>
 		</header>
 	);

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -1,4 +1,3 @@
-
 import "./i18n"; // ← this loads your i18n config and it should be the first import
 
 import React from "react";
@@ -7,20 +6,18 @@ import "./index.css";
 import OpenWebUIPage from "./App";
 import PrivacyPolicy from "./pages/PrivacyPolicy";
 import TermsOfService from "./pages/TermsOfService";
-import { BrowserRouter, Routes, Route } from "react-router-dom";
-
-const basename = "/";
+import { HashRouter, Routes, Route } from "react-router-dom"; // switched to HashRouter so GH pages work
 
 const root = ReactDOM.createRoot(document.getElementById("root"));
 
 root.render(
   <React.StrictMode>
-    <BrowserRouter basename={basename}>
+    <HashRouter>
       <Routes>
         <Route path="/" element={<OpenWebUIPage />} />
         <Route path="/privacy" element={<PrivacyPolicy />} />
         <Route path="/terms" element={<TermsOfService />} />
       </Routes>
-    </BrowserRouter>
+    </HashRouter>
   </React.StrictMode>
 );


### PR DESCRIPTION
- We now use hash router since we deploy using GH pages and our app is SPA
- Fixed cookie control to be mobile friendly
- Fixed lang detection to work for all locales 
- Moved lang switcher to be part of the menu so it is visible on mobile
- Adjusted image urls not to use public since this is handled by vite